### PR TITLE
Support MuJoCo simulation with backwards compatible fake hardware flag

### DIFF
--- a/launch/display_openarm.launch.py
+++ b/launch/display_openarm.launch.py
@@ -133,7 +133,8 @@ def generate_launch_description():
 
     robot_state_publisher_loader = OpaqueFunction(
         function=robot_state_publisher_spawner,
-        args=[arm_type, ee_type, bimanual, ros2_control, hardware_type, use_fake_hardware]
+        args=[arm_type, ee_type, bimanual, ros2_control,
+              hardware_type, use_fake_hardware]
     )
 
     rviz_loader = OpaqueFunction(

--- a/launch/display_openarm.launch.py
+++ b/launch/display_openarm.launch.py
@@ -24,10 +24,21 @@ from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
-def robot_state_publisher_spawner(context: LaunchContext, arm_type, ee_type, bimanual):
+def robot_state_publisher_spawner(
+    context: LaunchContext,
+    arm_type,
+    ee_type,
+    bimanual,
+    ros2_control,
+    hardware_type,
+    use_fake_hardware,
+):
     arm_type_str = context.perform_substitution(arm_type)
     ee_type_str = context.perform_substitution(ee_type)
     bimanual_str = context.perform_substitution(bimanual)
+    ros2_control_str = context.perform_substitution(ros2_control)
+    hardware_type_str = context.perform_substitution(hardware_type)
+    use_fake_hardware_str = context.perform_substitution(use_fake_hardware)
 
     xacro_path = os.path.join(
         get_package_share_directory("openarm_description"),
@@ -40,6 +51,9 @@ def robot_state_publisher_spawner(context: LaunchContext, arm_type, ee_type, bim
             "arm_type": arm_type_str,
             "ee_type": ee_type_str,
             "bimanual": bimanual_str,
+            "ros2_control": ros2_control_str,
+            "hardware_type": hardware_type_str,
+            "use_fake_hardware": use_fake_hardware_str,
         }
     ).toprettyxml(indent="  ")
 
@@ -92,13 +106,34 @@ def generate_launch_description():
         description="Whether to use bimanual configuration"
     )
 
+    ros2_control_arg = DeclareLaunchArgument(
+        "ros2_control",
+        default_value="false",
+        description="Use ros2_control hardware interfaces in the robot description."
+    )
+
+    hardware_type_arg = DeclareLaunchArgument(
+        "hardware_type",
+        default_value="",
+        description="Hardware backend to use, defaults to use_fake_hardware."
+    )
+
+    use_fake_hardware_arg = DeclareLaunchArgument(
+        "use_fake_hardware",
+        default_value="false",
+        description="Deprecated flag for backwards compatibility."
+    )
+
     arm_type = LaunchConfiguration("arm_type")
     ee_type = LaunchConfiguration("ee_type")
     bimanual = LaunchConfiguration("bimanual")
+    ros2_control = LaunchConfiguration("ros2_control")
+    hardware_type = LaunchConfiguration("hardware_type")
+    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
 
     robot_state_publisher_loader = OpaqueFunction(
         function=robot_state_publisher_spawner,
-        args=[arm_type, ee_type, bimanual]
+        args=[arm_type, ee_type, bimanual, ros2_control, hardware_type, use_fake_hardware]
     )
 
     rviz_loader = OpaqueFunction(
@@ -110,6 +145,9 @@ def generate_launch_description():
         arm_type_arg,
         ee_type_arg,
         bimanual_arg,
+        ros2_control_arg,
+        hardware_type_arg,
+        use_fake_hardware_arg,
         robot_state_publisher_loader,
         Node(
             package="joint_state_publisher_gui",

--- a/launch/display_openarm.launch.py
+++ b/launch/display_openarm.launch.py
@@ -115,7 +115,7 @@ def generate_launch_description():
     hardware_type_arg = DeclareLaunchArgument(
         "hardware_type",
         default_value="",
-        description="Hardware backend to use, defaults to use_fake_hardware."
+        description="Hardware backend to use (real/mock/mujoco)."
     )
 
     use_fake_hardware_arg = DeclareLaunchArgument(

--- a/urdf/robot/openarm_robot.xacro
+++ b/urdf/robot/openarm_robot.xacro
@@ -20,7 +20,7 @@
             ee_type:=''
             ros2_control:=false
             can_interface:=''
-            hardware_type:='real'
+            hardware_type:=''
             use_fake_hardware:=false
             fake_sensor_commands:=false
             no_prefix:='false'

--- a/urdf/robot/openarm_robot.xacro
+++ b/urdf/robot/openarm_robot.xacro
@@ -20,6 +20,7 @@
             ee_type:=''
             ros2_control:=false
             can_interface:=''
+            hardware_type:='real'
             use_fake_hardware:=false
             fake_sensor_commands:=false
             no_prefix:='false'
@@ -54,6 +55,9 @@
 
     <xacro:property name="arm_prefix_modified" value="${'' if arm_prefix == '' else arm_prefix + '_'}" />
     <xacro:property name="body_prefix_modified" value="${'' if body_prefix == '' else body_prefix + '_'}" />
+    <xacro:property
+        name="hardware"
+        value="${hardware_type if hardware_type != '' else ('mock' if use_fake_hardware else 'real')}" />
 
     <xacro:if value="${bimanual}">
 
@@ -106,7 +110,7 @@
             control_gains="${control_gains}"
             left_can_interface="${left_can_interface}"
             right_can_interface="${right_can_interface}"
-            use_fake_hardware="${use_fake_hardware}"
+            hardware_type="${hardware}"
             fake_sensor_commands="${fake_sensor_commands}"
             left_arm_prefix="${left_arm_prefix}"
             right_arm_prefix="${right_arm_prefix}"
@@ -165,7 +169,7 @@
             control_gains="${control_gains}"
             arm_prefix="${arm_prefix_modified}"
             can_interface="${can_interface}"
-            use_fake_hardware="${use_fake_hardware}"
+            hardware_type="${hardware}"
             fake_sensor_commands="${fake_sensor_commands}"
             hand="${hand}"
             bimanual="false"

--- a/urdf/robot/v10.urdf.xacro
+++ b/urdf/robot/v10.urdf.xacro
@@ -35,6 +35,7 @@
 
   <xacro:arg name="right_arm_prefix" default="right_" />
 
+  <xacro:arg name="hardware_type" default="" />
   <xacro:arg name="use_fake_hardware" default="false" />
 
   <xacro:arg name="fake_sensor_commands" default="false" />
@@ -70,6 +71,7 @@
   right_can_interface="$(arg right_can_interface)"
   left_arm_prefix="$(arg left_arm_prefix)"
   right_arm_prefix="$(arg right_arm_prefix)"
+  hardware_type="$(arg hardware_type)"
   use_fake_hardware="$(arg use_fake_hardware)"
   fake_sensor_commands="$(arg fake_sensor_commands)"
   no_prefix="$(arg no_prefix)"

--- a/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
+++ b/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
@@ -7,6 +7,8 @@
              left_can_interface:=^|can1
              right_can_interface:=^|can0
              hardware_type:=^|real
+             left_websocket_port:=^|1337
+             right_websocket_port:=^|1338
              fake_sensor_commands:=^|false
              hand:=^|false
              left_arm_prefix:=^|left_
@@ -17,6 +19,10 @@
     <ros2_control name="openarm_left_hardware_interface" type="system">
         <hardware>
           <param name="arm_type">${arm_type}</param>
+          <xacro:if value="${hardware_type == 'mujoco'}">
+            <plugin>openarm_mujoco_hardware/MujocoHardware</plugin>
+            <param name="websocket_port">${left_websocket_port}</param>
+          </xacro:if>
           <xacro:if value="${hardware_type == 'mock'}">
             <plugin>mock_components/GenericSystem</plugin>
             <param name="fake_sensor_commands">${fake_sensor_commands}</param>
@@ -82,6 +88,10 @@
     <ros2_control name="openarm_right_hardware_interface" type="system">
         <hardware>
           <param name="arm_type">${arm_type}</param>
+          <xacro:if value="${hardware_type == 'mujoco'}">
+            <plugin>openarm_mujoco_hardware/MujocoHardware</plugin>
+            <param name="websocket_port">${right_websocket_port}</param>
+          </xacro:if>
           <xacro:if value="${hardware_type == 'mock'}">
             <plugin>mock_components/GenericSystem</plugin>
             <param name="fake_sensor_commands">${fake_sensor_commands}</param>

--- a/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
+++ b/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
@@ -6,7 +6,7 @@
              control_gains
              left_can_interface:=^|can1
              right_can_interface:=^|can0
-             use_fake_hardware:=^|false
+             hardware_type:=^|real
              fake_sensor_commands:=^|false
              hand:=^|false
              left_arm_prefix:=^|left_
@@ -17,12 +17,12 @@
     <ros2_control name="openarm_left_hardware_interface" type="system">
         <hardware>
           <param name="arm_type">${arm_type}</param>
-          <xacro:if value="${use_fake_hardware}">
+          <xacro:if value="${hardware_type == 'mock'}">
             <plugin>mock_components/GenericSystem</plugin>
             <param name="fake_sensor_commands">${fake_sensor_commands}</param>
             <param name="state_following_offset">0.0</param>
           </xacro:if>
-          <xacro:unless value="${use_fake_hardware}">
+          <xacro:if value="${hardware_type == 'real'}">
             <plugin>openarm_hardware/OpenArm_v10HW</plugin>
             <param name="can_interface">${left_can_interface}</param>
             <param name="arm_prefix">${left_arm_prefix}</param>
@@ -42,7 +42,7 @@
             <param name="kd5">${control_gains['joint5']['kd']}</param>
             <param name="kd6">${control_gains['joint6']['kd']}</param>
             <param name="kd7">${control_gains['joint7']['kd']}</param>
-          </xacro:unless>
+          </xacro:if>
         </hardware>
 
       <xacro:macro name="configure_joint" params="joint_name initial_position">
@@ -82,12 +82,12 @@
     <ros2_control name="openarm_right_hardware_interface" type="system">
         <hardware>
           <param name="arm_type">${arm_type}</param>
-          <xacro:if value="${use_fake_hardware}">
+          <xacro:if value="${hardware_type == 'mock'}">
             <plugin>mock_components/GenericSystem</plugin>
             <param name="fake_sensor_commands">${fake_sensor_commands}</param>
             <param name="state_following_offset">0.0</param>
           </xacro:if>
-          <xacro:unless value="${use_fake_hardware}">
+          <xacro:if value="${hardware_type == 'real'}">
             <plugin>openarm_hardware/OpenArm_v10HW</plugin>
             <param name="can_interface">${right_can_interface}</param>
             <param name="arm_prefix">${right_arm_prefix}</param>
@@ -107,7 +107,7 @@
             <param name="kd5">${control_gains['joint5']['kd']}</param>
             <param name="kd6">${control_gains['joint6']['kd']}</param>
             <param name="kd7">${control_gains['joint7']['kd']}</param>
-          </xacro:unless>
+          </xacro:if>
         </hardware>
 
       <xacro:configure_joint joint_name="openarm_${right_arm_prefix}joint1" initial_position="0.0"/>

--- a/urdf/ros2_control/openarm.ros2_control.xacro
+++ b/urdf/ros2_control/openarm.ros2_control.xacro
@@ -5,7 +5,7 @@
          params="arm_type
              control_gains
              can_interface
-             use_fake_hardware:=^|false
+             hardware_type:=^|real
              fake_sensor_commands:=^|false
              hand:=^|false
              gazebo_effort:=^|false
@@ -17,12 +17,12 @@
         <hardware>
           <param name="arm_type">${arm_type}</param>
           <param name="prefix">${arm_prefix}</param>
-          <xacro:if value="${use_fake_hardware}">
+          <xacro:if value="${hardware_type == 'mock'}">
             <plugin>mock_components/GenericSystem</plugin>
             <param name="fake_sensor_commands">${fake_sensor_commands}</param>
             <param name="state_following_offset">0.0</param>
           </xacro:if>
-          <xacro:if value="${use_fake_hardware == 0}">
+          <xacro:if value="${hardware_type == 'real'}">
             <plugin>openarm_hardware/OpenArm_${arm_type}HW</plugin>
             <param name="can_interface">${can_interface}</param>
             <param name="arm_prefix">${arm_prefix}</param>

--- a/urdf/ros2_control/openarm.ros2_control.xacro
+++ b/urdf/ros2_control/openarm.ros2_control.xacro
@@ -11,12 +11,17 @@
              gazebo_effort:=^|false
              arm_prefix:=''
              bimanual:=false
-             can_fd:=^|true">
+             can_fd:=^|true
+             websocket_port:=1337">
 
     <ros2_control name="openarm_hardware_interface" type="system">
         <hardware>
           <param name="arm_type">${arm_type}</param>
           <param name="prefix">${arm_prefix}</param>
+          <xacro:if value="${hardware_type == 'mujoco'}">
+            <plugin>openarm_mujoco_hardware/MujocoHardware</plugin>
+            <param name="websocket_port">${websocket_port}</param>
+          </xacro:if>
           <xacro:if value="${hardware_type == 'mock'}">
             <plugin>mock_components/GenericSystem</plugin>
             <param name="fake_sensor_commands">${fake_sensor_commands}</param>


### PR DESCRIPTION
This adds support for MuJoCo hardware interfaces in the URDF, which is required for upstream framework integrations like MoveIt2