### PR TITLE
Switch default can interfaces

### DIFF
--- a/urdf/robot/openarm_robot.xacro
+++ b/urdf/robot/openarm_robot.xacro
@@ -31,8 +31,8 @@
             left_arm_base_xyz='0 0 0'
             right_arm_base_rpy='0 0 0'
             left_arm_base_rpy='0 0 0'
-            left_can_interface:='can1'
-            right_can_interface:='can0'
+            left_can_interface:='can0'
+            right_can_interface:='can1'
             left_arm_prefix:='left_'
             right_arm_prefix:='right_'
             "

--- a/urdf/robot/v10.urdf.xacro
+++ b/urdf/robot/v10.urdf.xacro
@@ -27,9 +27,9 @@
 
   <xacro:arg name="can_interface" default="can0" />
 
-  <xacro:arg name="left_can_interface" default="can1" />
+  <xacro:arg name="left_can_interface" default="can0" />
 
-  <xacro:arg name="right_can_interface" default="can0" />
+  <xacro:arg name="right_can_interface" default="can1" />
 
   <xacro:arg name="left_arm_prefix" default="left_" />
 


### PR DESCRIPTION
To standardize calibration, expect `(left can % 2) == 0` and `(right can % 2) == 1`