### PR TITLE
urdf/ros2_control: use `mock_components` instead of `fake_components`

### DIFF
--- a/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
+++ b/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
@@ -17,7 +17,7 @@
         <hardware>
           <param name="arm_type">${arm_type}</param>
           <xacro:if value="${use_fake_hardware}">
-            <plugin>fake_components/GenericSystem</plugin>
+            <plugin>mock_components/GenericSystem</plugin>
             <param name="fake_sensor_commands">${fake_sensor_commands}</param>
             <param name="state_following_offset">0.0</param>
           </xacro:if>
@@ -68,7 +68,7 @@
         <hardware>
           <param name="arm_type">${arm_type}</param>
           <xacro:if value="${use_fake_hardware}">
-            <plugin>fake_components/GenericSystem</plugin>
+            <plugin>mock_components/GenericSystem</plugin>
             <param name="fake_sensor_commands">${fake_sensor_commands}</param>
             <param name="state_following_offset">0.0</param>
           </xacro:if>

--- a/urdf/ros2_control/openarm.ros2_control.xacro
+++ b/urdf/ros2_control/openarm.ros2_control.xacro
@@ -17,7 +17,7 @@
           <param name="arm_type">${arm_type}</param>
           <param name="prefix">${arm_prefix}</param>
           <xacro:if value="${use_fake_hardware}">
-            <plugin>fake_components/GenericSystem</plugin>
+            <plugin>mock_components/GenericSystem</plugin>
             <param name="fake_sensor_commands">${fake_sensor_commands}</param>
             <param name="state_following_offset">0.0</param>
           </xacro:if>


### PR DESCRIPTION
Fix https://github.com/enactic/openarm_ros2/issues/75

There is no mention of `fake_components` in the official documentation since Humble. We should currently use `mock_components`.
I have confirmed that it works in Humble and Jazzy.

Reported by @ncnynl. Thanks!!!