### PR TITLE
fix finger inertia

### DIFF
--- a/config/hand/openarm_hand/inertials.yaml
+++ b/config/hand/openarm_hand/inertials.yaml
@@ -28,9 +28,9 @@ left_finger:
     xx: 2.3749999999999997e-06
     yy: 2.3749999999999997e-06
     zz: 7.5e-07
-    xy: 1e-06
-    xz: 1e-06
-    yz: 1e-06
+    xy: 0
+    xz: 0
+    yz: 0
 
 right_finger:
   origin:
@@ -45,26 +45,6 @@ right_finger:
     xx: 2.3749999999999997e-06
     yy: 2.3749999999999997e-06
     zz: 7.5e-07
-    xy: 1e-06
-    xz: 1e-06
-    yz: 1e-06
-
-# left_finger: &finger
-#   origin:
-#     x: 00064528
-#     y: 0.017020
-#     z: 0.0219685
-#     roll: 0
-#     pitch: 0
-#     yaw: 0
-#   mass: 0.03602545343277134
-#   inertia:
-#     xx: 2.3749999999999997e-06
-#     yy: 2.3749999999999997e-06
-#     zz: 7.5e-07
-#     xy: 0
-#     xz: 0
-#     yz: 0
-# right_finger: *finger
-
-
+    xy: 0
+    xz: 0
+    yz: 0


### PR DESCRIPTION
GitHub fixes GH-36

Set inertia elements (xy, xz, yz) to 0 for finger links.
Fingers only move along a single axis, so 0 seems a better value.