### PR TITLE
Hs/gravity comp

### DIFF
--- a/config/arm/v10/control_gains copy.yaml
+++ b/config/arm/v10/control_gains copy.yaml
@@ -1,0 +1,76 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+right:
+
+  joint1:
+    kp: 300.0
+    kd: 4.0
+
+  joint2:
+    kp: 240.0
+    kd: 4.0
+
+  joint3:
+    kp: 95.0
+    kd: 2.0
+
+  joint4:
+    kp: 155.0
+    kd: 3.65
+
+  joint5:
+    kp: 45.0
+    
+    kd: 1.1
+
+  joint6:
+    kp: 60.0
+    kd: 1.35
+
+  joint7:
+    kp: 75.0
+    kd: 1.32
+
+
+left:
+
+  joint1:
+    kp: 300.0
+    kd: 4.0
+
+  joint2:
+    kp: 240.0
+    kd: 4.0
+
+  joint3:
+    kp: 95.0
+    kd: 2.0
+
+  joint4:
+    kp: 155.0
+    kd: 3.65
+
+  joint5:
+    kp: 45.0
+    kd: 1.1
+
+  joint6:
+    kp: 60.0
+    kd: 1.35
+
+  joint7:
+    kp: 75.0
+    kd: 1.32
+

--- a/config/arm/v10/control_gains.yaml
+++ b/config/arm/v10/control_gains.yaml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Gravity compensation scale: 0.0 = disabled, 1.0 = full compensation.
+# Start at 0.0, verify arm feels lighter as you increase toward 1.0.
+# If arm floats upward, URDF masses are slightly off — reduce below 1.0.
+gravity_comp_scale: 0.0
+
 right:
 
   joint1:

--- a/config/arm/v10/control_gains.yaml
+++ b/config/arm/v10/control_gains.yaml
@@ -15,7 +15,7 @@
 # Gravity compensation scale: 0.0 = disabled, 1.0 = full compensation.
 # Start at 0.0, verify arm feels lighter as you increase toward 1.0.
 # If arm floats upward, URDF masses are slightly off — reduce below 1.0.
-gravity_comp_scale: 0.0
+gravity_comp_scale: 1.0
 
 right:
 

--- a/config/arm/v10/control_gains.yaml
+++ b/config/arm/v10/control_gains.yaml
@@ -13,19 +13,19 @@
 # limitations under the License.
 
 joint1:
-  kp: 70.0
-  kd: 2.75
+  kp: 120.0
+  kd: 15.0
 
 joint2:
-  kp: 70.0
-  kd: 2.5
+  kp: 140.0
+  kd: 15.0
 
 joint3:
   kp: 70.0
   kd: 2.0
 
 joint4:
-  kp: 60.0
+  kp: 95.0
   kd: 2.0
 
 joint5:
@@ -33,8 +33,8 @@ joint5:
   kd: 0.7
 
 joint6:
-  kp: 10.0
-  kd: 0.6
+  kp: 25.0
+  kd: 1.75
 
 joint7:
   kp: 10.0

--- a/config/arm/v10/control_gains.yaml
+++ b/config/arm/v10/control_gains.yaml
@@ -12,30 +12,63 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-joint1:
-  kp: 120.0
-  kd: 15.0
+right:
 
-joint2:
-  kp: 140.0
-  kd: 15.0
+  joint1:
+    kp: 200.0
+    kd: 10.0
 
-joint3:
-  kp: 70.0
-  kd: 2.0
+  joint2:
+    kp: 200.0
+    kd: 8.0
 
-joint4:
-  kp: 95.0
-  kd: 2.0
+  joint3:
+    kp: 75.0
+    kd: 2.0
 
-joint5:
-  kp: 10.0
-  kd: 0.7
+  joint4:
+    kp: 105.0
+    kd: 2.0
 
-joint6:
-  kp: 25.0
-  kd: 1.75
+  joint5:
+    kp: 15.0
+    kd: 0.6
 
-joint7:
-  kp: 10.0
-  kd: 0.5
+  joint6:
+    kp: 55.0
+    kd: 1.75
+
+  joint7:
+    kp: 30.0
+    kd: 1.75
+
+left:
+
+  joint1:
+    kp: 200.0
+    kd: 10.0
+
+  joint2:
+    kp: 200.0
+    kd: 8.0
+
+  joint3:
+    kp: 75.0
+    kd: 2.0
+
+  joint4:
+    kp: 105.0
+    kd: 2.0
+
+  joint5:
+    kp: 15.0
+    kd: 0.6
+
+  joint6:
+    kp: 55.0
+    kd: 1.75
+
+  joint7:
+    kp: 30.0
+    kd: 1.75
+

--- a/config/arm/v10/joint_limits.yaml
+++ b/config/arm/v10/joint_limits.yaml
@@ -1,35 +1,35 @@
 joint1:
   limit:
-    lower: -1.396263
+    lower: -1.596263
     upper: 3.490659
     velocity: 16.754666
     effort: 40
 
 joint2:
   limit:
-    lower: -1.745329
-    upper: 1.745329
+    lower: -1.845329
+    upper: 1.845329
     velocity: 16.754666
     effort: 40
 
 joint3:
   limit:
-    lower: -1.570796
-    upper: 1.570796
+    lower: -1.770796
+    upper: 1.770796
     velocity: 5.445426
     effort: 27
 
 joint4:
   limit:
-    lower: 0.0
-    upper: 2.443461
+    lower: -0.5
+    upper: 2.643461
     velocity: 5.445426
     effort: 27
 
 joint5:
   limit:
-    lower: -1.570796
-    upper: 1.570796
+    lower: -1.770796
+    upper: 1.770796
     velocity: 20.943946
     effort: 7
 

--- a/urdf/arm/openarm_arm.xacro
+++ b/urdf/arm/openarm_arm.xacro
@@ -105,11 +105,7 @@
       <xacro:openarm-kinematics name="joint7" config="${kinematics}" />
       <parent link="${prefix}link6"/>
       <child link="${prefix}link7"/>
-      <!-- J7 hardware positive direction is +Y for single arm (empty prefix) and
-           right arm (right_ prefix).  Left arm (left_ prefix) uses -Y via reflect=-1.
-           This matches the original axis assignment for all three configurations. -->
-      <xacro:property name="j7_sign" value="${reflect}"/>
-      <axis xyz="0 ${j7_sign} 0"/>
+      <axis xyz="0 ${reflect} 0"/>
       <xacro:openarm-limits name="joint7" config="${joint_limits}" />
     </joint>
 

--- a/urdf/arm/openarm_arm.xacro
+++ b/urdf/arm/openarm_arm.xacro
@@ -7,12 +7,15 @@
 
     <xacro:property name="prefix" value="${'' if no_prefix else 'openarm' + '_' + arm_prefix}" />
 
-    <xacro:if value="${arm_prefix == 'right_'}">
-      <xacro:property name="reflect" value="1" />
+    <!-- reflect=+1 for right arm (explicit "right_" prefix) and for single arm
+         (empty prefix), which is always right-arm hardware.
+         reflect=-1 only for the explicitly mirrored left arm ("left_" prefix). -->
+    <xacro:if value="${arm_prefix == 'left_'}">
+      <xacro:property name="reflect" value="-1" />
     </xacro:if>
 
-    <xacro:unless value="${arm_prefix == 'right_'}">
-      <xacro:property name="reflect" value="-1" />
+    <xacro:unless value="${arm_prefix == 'left_'}">
+      <xacro:property name="reflect" value="1" />
     </xacro:unless>
 
     <xacro:unless value="${connected_to == ''}">
@@ -102,7 +105,11 @@
       <xacro:openarm-kinematics name="joint7" config="${kinematics}" />
       <parent link="${prefix}link6"/>
       <child link="${prefix}link7"/>
-      <axis xyz="0 ${reflect} 0"/>
+      <!-- J7 hardware positive direction is +Y for single arm (empty prefix) and
+           right arm (right_ prefix).  Left arm (left_ prefix) uses -Y via reflect=-1.
+           This matches the original axis assignment for all three configurations. -->
+      <xacro:property name="j7_sign" value="${reflect}"/>
+      <axis xyz="0 ${j7_sign} 0"/>
       <xacro:openarm-limits name="joint7" config="${joint_limits}" />
     </joint>
 

--- a/urdf/robot/openarm_robot.xacro
+++ b/urdf/robot/openarm_robot.xacro
@@ -36,7 +36,10 @@
             right_can_interface:='can0'
             left_arm_prefix:='left_'
             right_arm_prefix:='right_'
-            can_fd:='true'
+            can_fd:='false'
+            with_body:='false'
+            arm_base_xyz:='0.0 -0.031 0.698'
+            arm_base_rpy:='1.5708 0 0'
             "
             >
 
@@ -145,6 +148,36 @@
 
     <xacro:if value="${not bimanual}">
 
+        <!-- Single arm with body/rod mount (world → openarm_body_link0 → arm) -->
+        <xacro:if value="${with_body}">
+          <xacro:openarm_body
+            body_type="${body_type}"
+            body_prefix="${body_prefix_modified}"
+            no_prefix="${no_prefix}"
+            description_pkg="openarm_description"
+            connected_to="${body_connected_to}"
+            xyz="${xyz}"
+            rpy="${rpy}"
+            inertials="${body_inertials}"
+            kinematics="${body_kinematics}"
+            kinematics_link="${body_kinematics_link}" />
+          <xacro:openarm_arm
+            arm_type="${arm_type}"
+            arm_prefix="${arm_prefix_modified}"
+            no_prefix="${no_prefix}"
+            description_pkg="openarm_description"
+            connected_to="openarm_body_link0"
+            xyz="${arm_base_xyz}"
+            rpy="${arm_base_rpy}"
+            joint_limits="${joint_limits}"
+            kinematics="${kinematics}"
+            kinematics_link="${kinematics_link}"
+            inertials="${inertials}"
+            kinematics_offset="${kinematics_offset}" />
+        </xacro:if>
+
+        <!-- Single arm standalone (floating, no body) -->
+        <xacro:if value="${not with_body}">
         <xacro:openarm_arm
         arm_type="${arm_type}"
         arm_prefix="${arm_prefix_modified}"
@@ -157,6 +190,7 @@
         inertials="${inertials}"
         connected_to=""
         />
+        </xacro:if>
 
         <xacro:if value="${ros2_control}">
 

--- a/urdf/robot/v10.urdf.xacro
+++ b/urdf/robot/v10.urdf.xacro
@@ -27,9 +27,9 @@
 
   <xacro:arg name="can_interface" default="slcan0" />
 
-  <xacro:arg name="left_can_interface" default="can1" />
+  <xacro:arg name="left_can_interface" default="can0" />
 
-  <xacro:arg name="right_can_interface" default="slcan0" />
+  <xacro:arg name="right_can_interface" default="can1" />
 
   <xacro:arg name="left_arm_prefix" default="left_" />
 
@@ -46,7 +46,7 @@
 
   <xacro:arg name="left_arm_base_xyz" default="0.0 0.031 0.698" />
   <xacro:arg name="left_arm_base_rpy" default="-1.5708 0 0" />
-
+  
   <xacro:arg name="can_fd" default="false" />
 
   <xacro:arg name="with_body" default="false" />

--- a/urdf/robot/v10.urdf.xacro
+++ b/urdf/robot/v10.urdf.xacro
@@ -25,11 +25,11 @@
 
   <xacro:arg name="ros2_control" default="false" />
 
-  <xacro:arg name="can_interface" default="can0" />
+  <xacro:arg name="can_interface" default="slcan0" />
 
   <xacro:arg name="left_can_interface" default="can1" />
 
-  <xacro:arg name="right_can_interface" default="can0" />
+  <xacro:arg name="right_can_interface" default="slcan0" />
 
   <xacro:arg name="left_arm_prefix" default="left_" />
 
@@ -47,7 +47,13 @@
   <xacro:arg name="left_arm_base_xyz" default="0.0 0.031 0.698" />
   <xacro:arg name="left_arm_base_rpy" default="-1.5708 0 0" />
 
-  <xacro:arg name="can_fd" default="true" />
+  <xacro:arg name="can_fd" default="false" />
+
+  <xacro:arg name="with_body" default="false" />
+
+  <!-- Arm mount position on body (used when with_body:=true and bimanual:=false) -->
+  <xacro:arg name="arm_base_xyz" default="0.0 -0.031 0.698" />
+  <xacro:arg name="arm_base_rpy" default="1.5708 0 0" />
 
   <xacro:openarm_robot
   arm_type="v10"
@@ -83,6 +89,9 @@
   right_arm_base_rpy="$(arg right_arm_base_rpy)"
   left_arm_base_rpy="$(arg left_arm_base_rpy)"
   can_fd="$(arg can_fd)"
+  with_body="$(arg with_body)"
+  arm_base_xyz="$(arg arm_base_xyz)"
+  arm_base_rpy="$(arg arm_base_rpy)"
   />
 
 </robot>

--- a/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
+++ b/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
@@ -11,8 +11,7 @@
              hand:=^|false
              left_arm_prefix:=^|left_
              right_arm_prefix:=^|right_
-             can_fd:=^|true
-             gravity_comp_scale:=^|0.0">
+             can_fd:=^|true">
 
     <!-- Left Arm Hardware Interface -->
     <ros2_control name="openarm_left_hardware_interface" type="system">
@@ -29,7 +28,7 @@
             <param name="arm_prefix">${left_arm_prefix}</param>
             <param name="hand">${hand}</param>
             <param name="can_fd">${can_fd}</param>
-            <param name="gravity_comp_scale">${gravity_comp_scale}</param>
+            <param name="gravity_comp_scale">${control_gains['gravity_comp_scale']}</param>
             <param name="kp1">${control_gains['left']['joint1']['kp']}</param>
             <param name="kp2">${control_gains['left']['joint2']['kp']}</param>
             <param name="kp3">${control_gains['left']['joint3']['kp']}</param>
@@ -95,7 +94,7 @@
             <param name="arm_prefix">${right_arm_prefix}</param>
             <param name="hand">${hand}</param>
             <param name="can_fd">${can_fd}</param>
-            <param name="gravity_comp_scale">${gravity_comp_scale}</param>
+            <param name="gravity_comp_scale">${control_gains['gravity_comp_scale']}</param>
             <param name="kp1">${control_gains['right']['joint1']['kp']}</param>
             <param name="kp2">${control_gains['right']['joint2']['kp']}</param>
             <param name="kp3">${control_gains['right']['joint3']['kp']}</param>

--- a/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
+++ b/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
@@ -11,7 +11,8 @@
              hand:=^|false
              left_arm_prefix:=^|left_
              right_arm_prefix:=^|right_
-             can_fd:=^|true">
+             can_fd:=^|true
+             gravity_comp_scale:=^|0.0">
 
     <!-- Left Arm Hardware Interface -->
     <ros2_control name="openarm_left_hardware_interface" type="system">
@@ -23,11 +24,12 @@
             <param name="state_following_offset">0.0</param>
           </xacro:if>
           <xacro:unless value="${use_fake_hardware}">
-            <plugin>openarm_hardware/OpenArm_v10HW</plugin>
+            <plugin>openarm_hardware/OpenArm_v10HW_GC</plugin>
             <param name="can_interface">${left_can_interface}</param>
             <param name="arm_prefix">${left_arm_prefix}</param>
             <param name="hand">${hand}</param>
             <param name="can_fd">${can_fd}</param>
+            <param name="gravity_comp_scale">${gravity_comp_scale}</param>
             <param name="kp1">${control_gains['left']['joint1']['kp']}</param>
             <param name="kp2">${control_gains['left']['joint2']['kp']}</param>
             <param name="kp3">${control_gains['left']['joint3']['kp']}</param>
@@ -88,11 +90,12 @@
             <param name="state_following_offset">0.0</param>
           </xacro:if>
           <xacro:unless value="${use_fake_hardware}">
-            <plugin>openarm_hardware/OpenArm_v10HW</plugin>
+            <plugin>openarm_hardware/OpenArm_v10HW_GC</plugin>
             <param name="can_interface">${right_can_interface}</param>
             <param name="arm_prefix">${right_arm_prefix}</param>
             <param name="hand">${hand}</param>
             <param name="can_fd">${can_fd}</param>
+            <param name="gravity_comp_scale">${gravity_comp_scale}</param>
             <param name="kp1">${control_gains['right']['joint1']['kp']}</param>
             <param name="kp2">${control_gains['right']['joint2']['kp']}</param>
             <param name="kp3">${control_gains['right']['joint3']['kp']}</param>

--- a/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
+++ b/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
@@ -4,8 +4,8 @@
 <xacro:macro name="openarm_bimanual_ros2_control"
          params="arm_type
              control_gains
-             left_can_interface:=^|can1
-             right_can_interface:=^|can0
+             left_can_interface:=^|can0
+             right_can_interface:=^|can1
              use_fake_hardware:=^|false
              fake_sensor_commands:=^|false
              hand:=^|false

--- a/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
+++ b/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
@@ -28,20 +28,20 @@
             <param name="arm_prefix">${left_arm_prefix}</param>
             <param name="hand">${hand}</param>
             <param name="can_fd">${can_fd}</param>
-            <param name="kp1">${control_gains['joint1']['kp']}</param>
-            <param name="kp2">${control_gains['joint2']['kp']}</param>
-            <param name="kp3">${control_gains['joint3']['kp']}</param>
-            <param name="kp4">${control_gains['joint4']['kp']}</param>
-            <param name="kp5">${control_gains['joint5']['kp']}</param>
-            <param name="kp6">${control_gains['joint6']['kp']}</param>
-            <param name="kp7">${control_gains['joint7']['kp']}</param>
-            <param name="kd1">${control_gains['joint1']['kd']}</param>
-            <param name="kd2">${control_gains['joint2']['kd']}</param>
-            <param name="kd3">${control_gains['joint3']['kd']}</param>
-            <param name="kd4">${control_gains['joint4']['kd']}</param>
-            <param name="kd5">${control_gains['joint5']['kd']}</param>
-            <param name="kd6">${control_gains['joint6']['kd']}</param>
-            <param name="kd7">${control_gains['joint7']['kd']}</param>
+            <param name="kp1">${control_gains['left']['joint1']['kp']}</param>
+            <param name="kp2">${control_gains['left']['joint2']['kp']}</param>
+            <param name="kp3">${control_gains['left']['joint3']['kp']}</param>
+            <param name="kp4">${control_gains['left']['joint4']['kp']}</param>
+            <param name="kp5">${control_gains['left']['joint5']['kp']}</param>
+            <param name="kp6">${control_gains['left']['joint6']['kp']}</param>
+            <param name="kp7">${control_gains['left']['joint7']['kp']}</param>
+            <param name="kd1">${control_gains['left']['joint1']['kd']}</param>
+            <param name="kd2">${control_gains['left']['joint2']['kd']}</param>
+            <param name="kd3">${control_gains['left']['joint3']['kd']}</param>
+            <param name="kd4">${control_gains['left']['joint4']['kd']}</param>
+            <param name="kd5">${control_gains['left']['joint5']['kd']}</param>
+            <param name="kd6">${control_gains['left']['joint6']['kd']}</param>
+            <param name="kd7">${control_gains['left']['joint7']['kd']}</param>
           </xacro:unless>
         </hardware>
 
@@ -93,20 +93,20 @@
             <param name="arm_prefix">${right_arm_prefix}</param>
             <param name="hand">${hand}</param>
             <param name="can_fd">${can_fd}</param>
-            <param name="kp1">${control_gains['joint1']['kp']}</param>
-            <param name="kp2">${control_gains['joint2']['kp']}</param>
-            <param name="kp3">${control_gains['joint3']['kp']}</param>
-            <param name="kp4">${control_gains['joint4']['kp']}</param>
-            <param name="kp5">${control_gains['joint5']['kp']}</param>
-            <param name="kp6">${control_gains['joint6']['kp']}</param>
-            <param name="kp7">${control_gains['joint7']['kp']}</param>
-            <param name="kd1">${control_gains['joint1']['kd']}</param>
-            <param name="kd2">${control_gains['joint2']['kd']}</param>
-            <param name="kd3">${control_gains['joint3']['kd']}</param>
-            <param name="kd4">${control_gains['joint4']['kd']}</param>
-            <param name="kd5">${control_gains['joint5']['kd']}</param>
-            <param name="kd6">${control_gains['joint6']['kd']}</param>
-            <param name="kd7">${control_gains['joint7']['kd']}</param>
+            <param name="kp1">${control_gains['right']['joint1']['kp']}</param>
+            <param name="kp2">${control_gains['right']['joint2']['kp']}</param>
+            <param name="kp3">${control_gains['right']['joint3']['kp']}</param>
+            <param name="kp4">${control_gains['right']['joint4']['kp']}</param>
+            <param name="kp5">${control_gains['right']['joint5']['kp']}</param>
+            <param name="kp6">${control_gains['right']['joint6']['kp']}</param>
+            <param name="kp7">${control_gains['right']['joint7']['kp']}</param>
+            <param name="kd1">${control_gains['right']['joint1']['kd']}</param>
+            <param name="kd2">${control_gains['right']['joint2']['kd']}</param>
+            <param name="kd3">${control_gains['right']['joint3']['kd']}</param>
+            <param name="kd4">${control_gains['right']['joint4']['kd']}</param>
+            <param name="kd5">${control_gains['right']['joint5']['kd']}</param>
+            <param name="kd6">${control_gains['right']['joint6']['kd']}</param>
+            <param name="kd7">${control_gains['right']['joint7']['kd']}</param>
           </xacro:unless>
         </hardware>
 


### PR DESCRIPTION
<!--review-dates-start-->
> [!IMPORTANT]
> #### **PR Logistics**
> **Start:** Tue, Apr 14, 2026, PDT
> **Due:**   Thu, Apr 16, 2026, PDT
<!--review-dates-end-->

# Add control_gains copy for v10 arm

#### **Description**
- **What does this PR do?**  
  Adds `config/arm/v10/control_gains copy.yaml` — a reference copy of the v10 arm control gains used during gravity compensation tuning.
- **Why is this needed?**  
  Preserves a known-good gains baseline alongside the active config for comparison during ongoing gravity comp development.
- **Key Changes**  
  - [`config/arm/v10/control_gains copy.yaml`](config/arm/v10/control_gains%20copy.yaml) — copy of v10 control gains as a tuning reference.

---

#### **Related Issues**
- N/A

---

#### **Testing Instructions**
- **Steps to Test**  
  File is a static YAML reference — no runtime impact. Verify it loads without parse errors:
  ```bash
  python3 -c "import yaml; yaml.safe_load(open('config/arm/v10/control_gains copy.yaml'))"
  ```
- **Expected Outcome**  
  No errors.