### PR TITLE
Add parsing of control gains for hand

### DIFF
--- a/config/arm/v10/control_gains.yaml
+++ b/config/arm/v10/control_gains.yaml
@@ -39,3 +39,7 @@ joint6:
 joint7:
   kp: 10.0
   kd: 0.5
+
+hand:
+  kp: 5.0
+  kd: 0.1

--- a/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
+++ b/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
@@ -42,6 +42,10 @@
             <param name="kd5">${control_gains['joint5']['kd']}</param>
             <param name="kd6">${control_gains['joint6']['kd']}</param>
             <param name="kd7">${control_gains['joint7']['kd']}</param>
+            <xacro:if value="${hand}">
+              <param name="kp_hand">${control_gains['hand']['kp']}</param>
+              <param name="kd_hand">${control_gains['hand']['kd']}</param>
+            </xacro:if>
           </xacro:unless>
         </hardware>
 
@@ -107,6 +111,10 @@
             <param name="kd5">${control_gains['joint5']['kd']}</param>
             <param name="kd6">${control_gains['joint6']['kd']}</param>
             <param name="kd7">${control_gains['joint7']['kd']}</param>
+            <xacro:if value="${hand}">
+              <param name="kp_hand">${control_gains['hand']['kp']}</param>
+              <param name="kd_hand">${control_gains['hand']['kd']}</param>
+            </xacro:if>
           </xacro:unless>
         </hardware>
 

--- a/urdf/ros2_control/openarm.ros2_control.xacro
+++ b/urdf/ros2_control/openarm.ros2_control.xacro
@@ -42,6 +42,10 @@
             <param name="kd5">${control_gains['joint5']['kd']}</param>
             <param name="kd6">${control_gains['joint6']['kd']}</param>
             <param name="kd7">${control_gains['joint7']['kd']}</param>
+            <xacro:if value="${hand}">
+              <param name="kph">${control_gains['hand']['kp']}</param>
+              <param name="kdh">${control_gains['hand']['kd']}</param>
+            </xacro:if>
           </xacro:if>
         </hardware>
 

--- a/urdf/ros2_control/openarm.ros2_control.xacro
+++ b/urdf/ros2_control/openarm.ros2_control.xacro
@@ -43,8 +43,8 @@
             <param name="kd6">${control_gains['joint6']['kd']}</param>
             <param name="kd7">${control_gains['joint7']['kd']}</param>
             <xacro:if value="${hand}">
-              <param name="kph">${control_gains['hand']['kp']}</param>
-              <param name="kdh">${control_gains['hand']['kd']}</param>
+              <param name="kp_hand">${control_gains['hand']['kp']}</param>
+              <param name="kd_hand">${control_gains['hand']['kd']}</param>
             </xacro:if>
           </xacro:if>
         </hardware>


### PR DESCRIPTION
Adds an additional set of control gains for the hand to be passed to ros2 control. See https://github.com/enactic/openarm_ros2/pull/88 for corresponding change to openarm_hardware.