### PR TITLE
modify: ee_type flag

### DIFF
--- a/assets/robot/openarm_v1.0/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
+++ b/assets/robot/openarm_v1.0/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
@@ -21,7 +21,7 @@ limitations under the License.
              right_can_interface:=^|can0
              use_fake_hardware:=^|true
              fake_sensor_commands:=^|false
-             hand:=^|false
+             hand:=^|true
              ee_type:=^|parallel_link
              left_arm_prefix:=^|left_
              right_arm_prefix:=^|right_
@@ -112,6 +112,7 @@ limitations under the License.
             <param name="arm_prefix">${right_arm_prefix}</param>
             <param name="hand">${hand}</param>
             <param name="can_fd">${can_fd}</param>
+            <param name="ee_type">${ee_type}</param>
             <param name="kp1">${control_gains['joint1']['kp']}</param>
             <param name="kp2">${control_gains['joint2']['kp']}</param>
             <param name="kp3">${control_gains['joint3']['kp']}</param>

--- a/assets/robot/openarm_v2.0/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
+++ b/assets/robot/openarm_v2.0/urdf/ros2_control/openarm.bimanual.ros2_control.xacro
@@ -21,7 +21,7 @@ limitations under the License.
              right_can_interface:=^|can0
              use_fake_hardware:=^|false
              fake_sensor_commands:=^|false
-             ee_type:=^|parallel_link
+             ee_type:=^|pinch_gripper
              left_arm_prefix:=^|left_
              right_arm_prefix:=^|right_
              left_finger_mimic_multiplier:=^|1.0
@@ -113,6 +113,7 @@ limitations under the License.
             <param name="can_interface">${right_can_interface}</param>
             <param name="arm_prefix">${right_arm_prefix}</param>
             <param name="can_fd">${can_fd}</param>
+            <param name="ee_type">${ee_type}</param>
             <param name="kp1">${control_gains['joint1']['kp']}</param>
             <param name="kp2">${control_gains['joint2']['kp']}</param>
             <param name="kp3">${control_gains['joint3']['kp']}</param>


### PR DESCRIPTION
## Summary

`ee_type` was not passed to the right arm hardware interface in the bimanual ros2_control xacro, causing the right arm to always fall back to the default value (`parallel_link`) regardless of what was specified.

## Changes

- Add `<param name="ee_type">${ee_type}</param>` to `openarm_right_hardware_interface` in `openarm.bimanual.ros2_control.xacro`
