### PR TITLE
config: restore missing hand control gains for v1.0

### DIFF
--- a/assets/robot/openarm_v1.0/config/arm/control_gains.yaml
+++ b/assets/robot/openarm_v1.0/config/arm/control_gains.yaml
@@ -39,3 +39,7 @@ joint6:
 joint7:
   kp: 10.0
   kd: 0.5
+
+hand:
+  kp: 5.0
+  kd: 0.1


### PR DESCRIPTION
GitHub fixes https://github.com/enactic/openarm_ros2/issues/92

The ROS 2 demo fails with an error, so this fixes it.
Restored what was lost in commit https://github.com/enactic/openarm_description/commit/d82e87d29dc46cef334f6e514311f2cc677d8970#diff-140e377051fc1947b0dbd8a0f32b52cb04a3cff22f517706e50430bce0d3576eL42-L45 .

Thanks for the report, fjesp!!!