### PR TITLE
Wire hand mesh into parallel gripper URDF and fix calibration

### DIFF
--- a/assets/end_effector/parallel_link/config/inertials.yaml
+++ b/assets/end_effector/parallel_link/config/inertials.yaml
@@ -12,6 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+hand:
+  origin:
+    x: 0.000001
+    y: 0.0
+    z: -0.000549
+    roll: 0
+    pitch: 0
+    yaw: 0
+  mass: 0.127
+  inertia:
+    xx: 1.65558e-04
+    yy: 1.74660e-05
+    zz: 1.73524e-04
+    xy: 0.0
+    xz: 0.0
+    yz: 0.0
+
 left_finger:
   origin:
     x: 0.0064528

--- a/assets/end_effector/parallel_link/config/kinematics.yaml
+++ b/assets/end_effector/parallel_link/config/kinematics.yaml
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+hand:
+  kinematic:
+    x: 0.0
+    y: 0.0
+    z: 0.1025
+    roll: 0
+    pitch: 0
+    yaw: 0
+
 finger_joint:
   kinematic:
     x: 0.0

--- a/assets/end_effector/parallel_link/config/kinematics.yaml
+++ b/assets/end_effector/parallel_link/config/kinematics.yaml
@@ -15,7 +15,7 @@
 finger_joint:
   kinematic:
     x: 0.0
-    y: 0.0
+    y: -0.005
     z: 0.1025
     roll: 0
     pitch: 0

--- a/assets/end_effector/parallel_link/config/kinematics_link.yaml
+++ b/assets/end_effector/parallel_link/config/kinematics_link.yaml
@@ -12,11 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+hand:
+  kinematic:
+    x: 0.0
+    y: 0.0
+    z: -0.661001
+    roll: 0.0
+    pitch: 0.0
+    yaw: 0.0
+
 left_finger:
   kinematic:
     x: 0.0
     y: -0.05
-    z: -0.673001
+    z: -0.661001
     roll: 0.0
     pitch: 0.0
     yaw: 0.0
@@ -25,7 +34,7 @@ right_finger:
   kinematic:
     x: 0.0
     y: 0.05
-    z: -0.673001
+    z: -0.661001
     roll: 0.0
     pitch: 0.0
     yaw: 0.0

--- a/assets/robot/openarm_v1.0/urdf/ee/parallel_link/openarm_parallel_gripper.xacro
+++ b/assets/robot/openarm_v1.0/urdf/ee/parallel_link/openarm_parallel_gripper.xacro
@@ -15,11 +15,11 @@ limitations under the License.
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="parallel_gripper">
 
   <!--
-    tcp_xyz default: 0 0 0.186 m along +Z of connected_to (link7).
-    Calibrated to place hand_tcp at the fingertip centre.
-    Units: metres. Override explicitly when mounting at a different offset.
+    tcp_xyz: offset from hand link to hand_tcp along +Z of hand (metres).
+    Default 0 0 0.0835 is the calibrated fingertip-centre offset for the
+    parallel-link gripper — measured from the hand frame origin.
   -->
-  <xacro:macro name="openarm_parallel_gripper" params="connected_to:='' arm_type arm_prefix:='' ee_type ee_inertials ee_kinematics ee_kinematics_link ee_joints_limits rpy_ee:='0 0 0' xyz_ee:='0 0 0' tcp_xyz:='0 0 0.186' tcp_rpy:='0 0 0' description_pkg:=openarm_description">
+  <xacro:macro name="openarm_parallel_gripper" params="connected_to:='' arm_type arm_prefix:='' ee_type ee_inertials ee_kinematics ee_kinematics_link ee_joints_limits rpy_ee:='0 0 0' xyz_ee:='0 0 0' tcp_xyz:='0 0 0.0835' tcp_rpy:='0 0 0' description_pkg:=openarm_description">
 
     <xacro:property name="ee_prefix" default=""/>
 
@@ -53,7 +53,7 @@ limitations under the License.
 
     <joint name="${ee_prefix}hand_tcp_joint" type="fixed">
       <origin xyz="${tcp_xyz}" rpy="${tcp_rpy}" />
-      <parent link="${connected_to}" /> <child link="${ee_prefix}hand_tcp" />
+      <parent link="${ee_prefix}hand" /> <child link="${ee_prefix}hand_tcp" />
     </joint>
 
     <link name="${ee_prefix}left_finger">

--- a/assets/robot/openarm_v1.0/urdf/ee/parallel_link/openarm_parallel_gripper.xacro
+++ b/assets/robot/openarm_v1.0/urdf/ee/parallel_link/openarm_parallel_gripper.xacro
@@ -35,11 +35,11 @@ limitations under the License.
           <mesh filename="package://${description_pkg}/assets/end_effector/parallel_link/meshes/collision/hand.stl" scale="0.001 0.001 0.001" />
         </geometry>
       </collision>
+      <xacro:ee-inertials name="hand"/>
     </link>
 
     <joint name="${ee_prefix}hand_joint" type="fixed">
-      <xacro:property name="fj" value="${ee_kinematics['finger_joint']['kinematic']}" />
-      <origin xyz="0 0 ${fj.z}" rpy="0 0 0" />
+      <xacro:openarm-ee-kinematics config="${ee_kinematics}" name="hand" />
       <parent link="${connected_to}" />
       <child link="${ee_prefix}hand" />
     </joint>

--- a/assets/robot/openarm_v1.0/urdf/ee/parallel_link/openarm_parallel_gripper.xacro
+++ b/assets/robot/openarm_v1.0/urdf/ee/parallel_link/openarm_parallel_gripper.xacro
@@ -14,13 +14,35 @@ limitations under the License.
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="parallel_gripper">
 
-  <xacro:macro name="openarm_parallel_gripper" params="connected_to:='' arm_type arm_prefix:='' ee_type ee_inertials ee_kinematics ee_kinematics_link ee_joints_limits rpy_ee:='0 0 0' xyz_ee:='0 0 0' tcp_xyz:='0 0 0' tcp_rpy:='0 0 0' description_pkg:=openarm_description">
+  <xacro:macro name="openarm_parallel_gripper" params="connected_to:='' arm_type arm_prefix:='' ee_type ee_inertials ee_kinematics ee_kinematics_link ee_joints_limits rpy_ee:='0 0 0' xyz_ee:='0 0 0' tcp_xyz:='0 0 0.1801' tcp_rpy:='0 0 0' description_pkg:=openarm_description">
 
     <xacro:property name="ee_prefix" default=""/>
 
     <xacro:unless value="${arm_type == ''}">
       <xacro:property name="ee_prefix" value="openarm_${arm_prefix}" />
     </xacro:unless>
+
+    <link name="${ee_prefix}hand">
+      <visual name="${ee_prefix}hand_visual">
+        <xacro:openarm-ee-kinematics-link config="${ee_kinematics_link}" name="hand" />
+        <geometry>
+          <mesh filename="package://${description_pkg}/assets/end_effector/parallel_link/meshes/visual/hand.dae" scale="0.001 0.001 0.001"/>
+        </geometry>
+      </visual>
+      <collision name="${ee_prefix}hand_collision">
+        <xacro:openarm-ee-kinematics-link config="${ee_kinematics_link}" name="hand" />
+        <geometry>
+          <mesh filename="package://${description_pkg}/assets/end_effector/parallel_link/meshes/collision/hand.stl" scale="0.001 0.001 0.001" />
+        </geometry>
+      </collision>
+    </link>
+
+    <joint name="${ee_prefix}hand_joint" type="fixed">
+      <xacro:property name="fj" value="${ee_kinematics['finger_joint']['kinematic']}" />
+      <origin xyz="0 0 ${fj.z}" rpy="0 0 0" />
+      <parent link="${connected_to}" />
+      <child link="${ee_prefix}hand" />
+    </joint>
 
     <link name="${ee_prefix}hand_tcp" />
 

--- a/assets/robot/openarm_v1.0/urdf/ee/parallel_link/openarm_parallel_gripper.xacro
+++ b/assets/robot/openarm_v1.0/urdf/ee/parallel_link/openarm_parallel_gripper.xacro
@@ -14,7 +14,12 @@ limitations under the License.
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="parallel_gripper">
 
-  <xacro:macro name="openarm_parallel_gripper" params="connected_to:='' arm_type arm_prefix:='' ee_type ee_inertials ee_kinematics ee_kinematics_link ee_joints_limits rpy_ee:='0 0 0' xyz_ee:='0 0 0' tcp_xyz:='0 0 0.1801' tcp_rpy:='0 0 0' description_pkg:=openarm_description">
+  <!--
+    tcp_xyz default: 0 0 0.186 m along +Z of connected_to (link7).
+    Calibrated to place hand_tcp at the fingertip centre.
+    Units: metres. Override explicitly when mounting at a different offset.
+  -->
+  <xacro:macro name="openarm_parallel_gripper" params="connected_to:='' arm_type arm_prefix:='' ee_type ee_inertials ee_kinematics ee_kinematics_link ee_joints_limits rpy_ee:='0 0 0' xyz_ee:='0 0 0' tcp_xyz:='0 0 0.186' tcp_rpy:='0 0 0' description_pkg:=openarm_description">
 
     <xacro:property name="ee_prefix" default=""/>
 


### PR DESCRIPTION
### Problem

The hand meshes/assets for `OpenArm v1.0` existed in the repo and were already used in `parallel_link_standalone.urdf.xacro`, but were never integrated into the actual robot URDF. Additionally, three calibration issues were present in the gripper configuration.

The **hand.dae**:

<img width="447" height="357" alt="image" src="https://github.com/user-attachments/assets/71fddc63-16c1-42ac-90be-005fa0a65739" />


### Changes
**openarm_parallel_gripper.xacro**

- Add `hand` link with visual and collision geometry using the existing mesh assets.
- Add `hand_joint` (fixed) placing the hand TF frame at the palm level (z = finger_joint.z from connected_to)
- Fix `tcp_xyz` default from `0 0 0` (TCP at link7) to `0 0 0.1801` (TCP at fingertip center)

**kinematics_link.yaml**

- Add hand entry with correct visual offset (z: -0.661001) for the hand mesh
- Fix finger mesh z offset: `-0.673001` -> `-0.661001` (verified against Isaac Sim)

**kinematics.yaml**

- Fix `finger_joint.y`: `0.0` -> `-0.005` to create the correct 10mm separation between finger frames at joint=0, matching the physical closed position measured via TF in Isaac Sim.

### Testing
Verified in Isaac Sim (ROS 2 Jazzy) with the bimanual OpenArm v1.0 configuration. Hand mesh correctly aligned with fingers, gripper closes without visual mesh intersection, TCP correctly placed at fingertip.

<img width="485/" height="465/2" alt="image" src="https://github.com/user-attachments/assets/d8d6a6d5-573f-400d-9045-641ea6c9166d" />
