### PR TITLE
fix(description): show all accepted arm_type values in error

### DIFF
--- a/launch/display_openarm.launch.py
+++ b/launch/display_openarm.launch.py
@@ -36,7 +36,7 @@ def resolve_arm_config(arm_type_str: str) -> tuple[str, str]:
     if arm_type_str not in VALID_ARM_TYPES:
         raise ValueError(
             f"Invalid arm_type: '{arm_type_str}'. "
-            f"Please specify openarm_v1.0 or openarm_v2.0."
+            f"Accepted values: {sorted(VALID_ARM_TYPES)}."
         )
     if any(x in arm_type_str for x in ("1.0", "10", "1_0")):
         return "openarm_v1.0", "openarm_v10.urdf.xacro"


### PR DESCRIPTION
Split from #71 as requested by @kou (thanks for the review!).

This PR does **one** thing: when an invalid `arm_type` is supplied, the error now lists every accepted value derived from `VALID_ARM_TYPES` instead of hardcoding `openarm_v1.0 or openarm_v2.0`. This keeps the message correct automatically as new arm types are added.

Companion to the URDF-cleanup split in the sibling PR.